### PR TITLE
Remove default env var

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,5 +26,3 @@ jobs:
         npm run build
         npm run lint
         npm run test
-      env:
-        CI: true


### PR DESCRIPTION
https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables

CI is always set to `true` so this is redundant.